### PR TITLE
Remove Apereo mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EQUELLA has been deployed for copyright resource collections, research materials
 With over 10 years of history, EQUELLA is a mature solution written for the Java platform.  In its recent history, EQUELLA was proprietary software licensed to adopters by Pearson.  Currently EQUELLA is in the process of becoming open source software, led by contributors from Unicon and Edalex Solutions.
 
 ## Join the Community
-* Join our Apereo Equella google groups, mailing lists and our [Apereo Slack channel](https://apereo.slack.com)
+* Join our [Apereo Slack channel](https://apereo.slack.com)
 * [Community Governance Model](community/communitygovernance.md)
 
 ## Release Notes

--- a/community/communitygovernance.md
+++ b/community/communitygovernance.md
@@ -27,8 +27,6 @@ Responsibilities:
 5.  Ensure that outstanding issues/proposals are not forgotten or ignored.
 6.  Serve as the PMC's initial contact point with the outside world.
 * Provide regular, monthly updates to the list of accomplishments on PMC Home page.
-* Schedule regular monthly teleconferences with Apereo Executive Director (Ian Dolphin).
-* Occasional attendance (via teleconference) at Apereo board meetings.
 10.  Serve as a the list owner and moderator for Equella Open Source mail lists.
 11.  Provide summary reports of PMC proposals and decisions.
 12.  Oversee PMC documentation in github.
@@ -74,8 +72,6 @@ Changes in status from active to emeritus and from emeritus to active will be de
 A PMC member, whether active or emeritus, may resign at any time for any reason.
 
 A PMC chair or vice-chair can be removed at any time, with or without cause, by a vote of no confidence comprising a simple majority of active PMC members.
-
-A PMC chair, PMC vice-chair or the entire PMC can be removed by the Apereo Board with or without cause by a vote of no confidence. 
 
 
 ## Voting


### PR DESCRIPTION
Per [incubation@ traffic](https://groups.google.com/a/apereo.org/d/msg/incubation/aL8mL9xN0z0/ZmTWatFcBQAJ), this is not yet an Apereo incubating project. There's great promise and hope in being an Apereo project. But not there yet.

So remove characterization of 

+ governance involving Apereo and 
+ using Apereo email list infrastructure.