### PR TITLE
add editor config

### DIFF
--- a/.edtiorconfig
+++ b/.edtiorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
normalizes encoding to prevent large stylistic diffs