### PR TITLE
Specify page title and descriptions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-slate
+title: openEQUELLA
+description: A digital repository providing a single platform to house your teaching and learning, research, media, and library content.


### PR DESCRIPTION
Currently the site is using a place holder title of equella.github.io.
It would be preferable to have the product's title and description so as
to present more polished

It used to look like (before):
![2018-11-19-162633_676x190_scrot](https://user-images.githubusercontent.com/43919233/48687969-0742f900-ec18-11e8-8c35-f784b2a6bfca.png)

With this change it will instead look like (after):
![2018-11-19-162553_731x274_scrot](https://user-images.githubusercontent.com/43919233/48687971-07db8f80-ec18-11e8-9de1-392c63178a67.png)
