### PR TITLE
Remove confusing title on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# openEquella Web and Documentation
-
 openEQUELLA is a digital repository that provides a single platform to house your teaching and learning, research, media, and library content.
 
 openEQUELLA has been deployed for copyright resource collections, research materials, managing and exposing materials through websites and portals, content authoring, workflow, institutional policy and organizational resources. openEQUELLA is currently in use in a wide range of schools, universities, colleges, TAFEs, departments of education, government agencies, and corporations worldwide.


### PR DESCRIPTION
Had a chat with others, and 'Web and Documentation' didn't make any
sense. And now with the header of the pages configured, on the landing
page I think it's fine to start with no title.