### PR TITLE
add git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Set line endings for known text files
+*.css       text eol=lf
+*.html      text eol=lf
+*.js        text eol=lf
+*.json      text eol=lf
+*.md        text eol=lf
+*.php       text eol=lf
+*.sh        text eol=lf
+*.txt       text eol=lf


### PR DESCRIPTION
For editors that don't support editor config.
Git config can apply apply the line ending format during commit to avoid churn.

https://www.git-scm.com/docs/gitattributes