### PR TITLE
Migrated server configs to separate page; added configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ With over 15 years of history, openEQUELLA is a mature solution written for the 
 ## Getting Started
 * [Installing openEquella - Quick Start Guide](gettingstarted/InstallingEquella.md)
 * [Known Working Supporting Software](server-administration/KnownWorkingSupportingSoftware.md)
+* [Server Configurations](server-administration/ServerConfigurations.md)
 
 ## Tutorials
 

--- a/guides/InstallationAdminGuide.md
+++ b/guides/InstallationAdminGuide.md
@@ -1,6 +1,6 @@
 [Home](https://openequella.github.io/)
 
-# Open Source EQUELLA® Installation and Administration Guide
+# openQUELLA Installation and Administration Guide
 
 [Installation Prerequisities](#installation-prerequisites)
 
@@ -393,46 +393,8 @@ Installation of the openEQUELLA server is now complete. Login to the institution
 
 Note: When using openEQUELLA on Windows and changing the equellaserver or equellaserver-config properties, you'll need to reinstall the service.
 
-### Available openEQUELLA Configs
+The list of possible openEQUELLA server configurations is [here](server-administration/ServerConfigurations.md).
 
-* Config: freetextIndex.defaultOperator = AND
-  * Release(s) Valid: 5.2? - 6.3+
-  * Location: optional.properties in /plugins/com.tle.core.freetext
-  * Comments: Indicates if default search terms should be performed with an implicit AND or OR. Defaults to AND
-
-* Config: can.access.internet = true
-  * Release(s) Valid: 6.1-QA2 - 6.3+
-  * Location: optional-config.properties
-  * Comments: Allows the URL checker to run. Defaults to true.
-
-* Config: com.tle.core.tasks.RemoveOldAuditLogs.daysBeforeRemoval = 120
-  * Release(s) Valid: At least 6.0-QA3,6.1-QA2, 6.2-GA+
-  * Location: optional-config.properties
-  * Comments: Set the number of days to keep audit logs in openEQUELLA before the scheduled task truncates them. Default is 120 days (~4 months).
-
-* Config: com.tle.core.tasks.RemoveDeletedItems.daysBeforeRemoval = 7
-  * Release(s) Valid: At least 6.4-QA3+
-  * Location: optional-config.properties
-  * Comments: Set the number of days to keep deleted items in openEQUELLA before the scheduled task purges them. Default is 7 days.
-
-### Internal openEQUELLA Configs
-
-These configurations should be used only with the utmost care.  
-
-* Config: tomcat.useBio = false
-  * Release(s) Valid: 6.4-GA +
-  * Location: optional-config
-  * Comments: Default is false (Tomcat will by default use the NIO connectors).
-
-* Config: tomcat.maxThreads = 100
-  * Release(s) 6.2-GA +
-  * Location: optional-config
-  * Comments: Default is 100.
-
-* Config: sessions.neverPersist = false
-  * Release(s) Valid: 6.3-GA +, 6.2-QA1 +
-  * Location: optional-config
-  * Comments: Default is 'false'. In 6.2-QA1 that setting this config to true will stop openEQUELLA from inserting data into tomcat_sessions.
 
 ### openEQUELLA URLs
 

--- a/server-administration/ServerConfigurations.md
+++ b/server-administration/ServerConfigurations.md
@@ -2,11 +2,11 @@
 
 # openEQUELLA Server Configurations
 
-[Primary Mandatory Config](#primary-mandatory-config)
+* [Primary Mandatory Config](#primary-mandatory-config)
 
-[Primary Optional Config](#primary-optional-config)
+* [Primary Optional Config](#primary-optional-config)
 
-[Lucene Optional Config](#lucene-optional-config)
+* [Lucene Optional Config](#lucene-optional-config)
 
 
 Unless otherwise noted:

--- a/server-administration/ServerConfigurations.md
+++ b/server-administration/ServerConfigurations.md
@@ -30,6 +30,7 @@ Unless otherwise noted:
 | can.access.internet | true | ~6.1-QA2 | | Allows the URL checker to run. |
 | com.tle.core.tasks.RemoveOldAuditLogs.daysBeforeRemoval | 120 | ~6.0-QA3 | | Set the number of days to keep audit logs in openEQUELLA before the scheduled task truncates them. |
 | com.tle.core.tasks.RemoveDeletedItems.daysBeforeRemoval | 7 | ~6.4-QA3 | | Set the number of days to keep deleted items in openEQUELLA before the scheduled task purges them. | 
+| tomcat.internalProxies | N/A | 2019.1.3 / 2019.2.0 | | Sets the Tomcat RemoteIpValve > InternalProxies.  This is needed when uploading files in the modern UI in some environments | 
 
 ## Lucene Optional Config
 **Location:** `{oeq-install-dir}/plugins/com.tle.core.freetext/optional.properties`

--- a/server-administration/ServerConfigurations.md
+++ b/server-administration/ServerConfigurations.md
@@ -3,8 +3,11 @@
 # openEQUELLA Server Configurations
 
 [Primary Mandatory Config](#primary-mandatory-config)
+
 [Primary Optional Config](#primary-optional-config)
+
 [Lucene Optional Config](#lucene-optional-config)
+
 
 Unless otherwise noted:
 * Configuration 'versions' with a `~` means 'at least', so, `~6.4-QA3` means the config is at least in versions 6.4-QA3, but could be in versions earlier than 6.4-QA3

--- a/server-administration/ServerConfigurations.md
+++ b/server-administration/ServerConfigurations.md
@@ -1,0 +1,39 @@
+[Home](https://openequella.github.io/)
+
+# openEQUELLA Server Configurations
+
+[Primary Mandatory Config](#primary-mandatory-config)
+[Primary Optional Config](#primary-optional-config)
+[Lucene Optional Config](#lucene-optional-config)
+
+Unless otherwise noted:
+* Configuration 'versions' with a `~` means 'at least', so, `~6.4-QA3` means the config is at least in versions 6.4-QA3, but could be in versions earlier than 6.4-QA3
+* Blank max versions means it's still an active configuration in `develop`
+
+## Primary Mandatory Config
+**Location:**  `{oeq-install-dir}/learningedge-config/mandatory-config.properties`
+
+| Config | Default | Min Version | Max Version | Comments |
+| ------ | ------ | ------ | ------ | ------ |
+| tomcat.useBio | false | 6.4-GA | | Tomcat will by default use the NIO connectors |
+| tomcat.maxThreads | 100 | 6.2-GA | | |
+| sessions.neverPersist | false | 6.2-QA1 / 6.3-GA | | Setting to `true` will stop openEQUELLA from inserting data into tomcat_sessions. |
+| ajp.address | 127.0.0.1 | 2020.2.0 | | Tomcat AJP connector address |
+| ajp.secret.required | true | 2020.2.0 | | Specifies if the Tomcat AJP connector should be required.  This is ignored if `ajp.secret` is set to a non-blank value that is not `ignore`. |
+| ajp.secret | ignore | 2020.2.0 | | Specifies the secret to use between the Tomcat AJP connector and the web server.  Setting to `ignore` will do just that. |
+
+## Primary Optional Config
+**Location:**  `{oeq-install-dir}/learningedge-config/optional-config.properties`
+
+| Config | Default | Min Version | Max Version | Comments |
+| ------ | ------ | ------ | ------ | ------ |
+| can.access.internet | true | ~6.1-QA2 | | Allows the URL checker to run. |
+| com.tle.core.tasks.RemoveOldAuditLogs.daysBeforeRemoval | 120 | ~6.0-QA3 | | Set the number of days to keep audit logs in openEQUELLA before the scheduled task truncates them. |
+| com.tle.core.tasks.RemoveDeletedItems.daysBeforeRemoval | 7 | ~6.4-QA3 | | Set the number of days to keep deleted items in openEQUELLA before the scheduled task purges them. | 
+
+## Lucene Optional Config
+**Location:** `{oeq-install-dir}/plugins/com.tle.core.freetext/optional.properties`
+
+| Config | Default | Min Version | Max Version | Comments |
+| ------ | ------ | ------ | ------ | ------ |
+| freetextIndex.defaultOperator | AND | ~6.4-QA3 | | Indicates if default search terms should be performed with an implicit AND or OR. |


### PR DESCRIPTION
Based on the discussion from https://github.com/openequella/openEQUELLA/wiki/CDM-2019-12 , I separated and cleaned up the configs list.

Also added configs from:
* https://github.com/openequella/openEQUELLA/pull/1583/
* https://github.com/openequella/openEQUELLA/pull/1361/