### PR TITLE
Fix formatting of SSL setup section

### DIFF
--- a/guides/InstallationAdminGuide.md
+++ b/guides/InstallationAdminGuide.md
@@ -491,19 +491,21 @@ An example directive is:
 
 ### Configure openEQUELLA with SSL
 
-1. Open **mandatory-config.properties** and ensure the https.port is enabled (uncommented).
-2. Open **optional-config.properties** and ensure the *userService.useXForwardedFor* is set to **true**.
-3. Ensure the Apache *modules mod_proxy, mod_proxy_http, ssl and headers* have been installed and enabled.
-4. Open the Apache **httpd.conf file** and add a **‘ProxyPass'** directive to the VirtualHost element, and the additional SSL directives:
-​
+1. Open **optional-config.properties** and ensure the *userService.useXForwardedFor* is set to
+   **true**.
+2. Ensure the Apache *modules mod_proxy, mod_proxy_http, ssl and headers* have been installed and
+   enabled.
+3. Open the Apache **httpd.conf file** and add a **‘ProxyPass'** directive to the VirtualHost
+   element, and the additional SSL directives:
+
 ```apache
 <VirtualHost *:443>
   ServerName {external-server-name}
   ProxyPass / http://{equella-host}:{http-port}/ nocanon
   ProxyPreserveHost On
-​
+
   RequestHeader set "X-Forwarded-Proto" "https"
-​
+
   ## SSL
   SSLEngine on
   SSLProxyEngine on
@@ -511,23 +513,26 @@ An example directive is:
   SSLCertificateKeyFile {path-to-cert.key}
 </VirtualHost>
 ```
-​
+
 Where:
-* ‘external-server-name’ must be either the hostname of an institution, or the hostname in mandatory-config.properties.
-* ‘equellahost’ is the host with the openEQUELLA installation (if it is on the same machine as the apache server, this would normally be localhost).
+
+* ‘external-server-name’ must be either the hostname of an institution, or the hostname in
+  mandatory-config.properties.
+* ‘equellahost’ is the host with the openEQUELLA installation (if it is on the same machine as the
+  apache server, this would normally be localhost).
 * ‘https.port’ is the property specified in mandatory-config.properties (defaults to port 8443).
 * ‘nocanon’ ensures URLs are passed through to the host without processing.
-​
+
 An example directive is:
-​
+
 ```apache
 <VirtualHost *:443>
   ServerName equella.example.com
   ProxyPass / http://equella.example.com:8443/ nocanon
   ProxyPreserveHost On
-​
+
   RequestHeader set "X-Forwarded-Proto" "https"
-​
+
   ## SSL
   SSLEngine on
   SSLProxyEngine on
@@ -535,12 +540,11 @@ An example directive is:
   SSLCertificateKeyFile /etc/ssl/mycert.key
 </VirtualHost>
 ```
-​
-5. Update the institution URL for https://... (e.g. https://equella.com).
 
-​
-NOTE: The above examples are for Apache HTTPD, but hardware SSL terminators (e.g. F5 load balancer) or other software terminators (e.g. Nginx) may be used.
+4. Update the institution URL for https://... (e.g. https://equella.com).
 
+NOTE: The above examples are for Apache HTTPD, but hardware SSL terminators (e.g. F5 load balancer)
+or other software terminators (e.g. Nginx) may be used.
 
 ## Customize the openEQUELLA Digital Repository
 


### PR DESCRIPTION
It had some invisible unicode characters attempting to providing blank
lines.

Also, you don't have to use the https.port for SSL reverse proxing to
oEQ so I removed that.