### PR TITLE
add 2023.1 to versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,11 @@
 [
 	{
+		"version": "2023.1.0",
+		"html_url": "https://github.com/openequella/openEQUELLA/releases/tag/2023.1.0",
+		"release_date": "2023-08-23",
+		"ref": "448a8ab644a2132b0173b27516596732bb5ffc0c"
+	},
+	{
 		"version": "2022.2.0",
 		"html_url": "https://github.com/openequella/openEQUELLA/releases/tag/2022.2.0",
 		"release_date": "2022-11-03",


### PR DESCRIPTION
Now that 2023.1 is released, we need to keep our versions file up to date.