### PR TITLE
add 2023.2 to versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,11 @@
 [
 	{
+		"version": "2023.2.0",
+		"html_url": "https://github.com/openequella/openEQUELLA/releases/tag/2023.2.0",
+		"release_date": "2023-12-12",
+		"ref": "2a0c535cc2bc4e8b66d06f78b6bbe9936c83cd2f"
+	},
+	{
 		"version": "2023.1.0",
 		"html_url": "https://github.com/openequella/openEQUELLA/releases/tag/2023.1.0",
 		"release_date": "2023-08-23",


### PR DESCRIPTION
Now that 2023.2 is released, we need to keep our versions file up to date.