### PR TITLE
Updated links for the openequella.github.io page

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ openEQUELLA is a digital repository that provides a single platform to house you
 
 openEQUELLA has been deployed for copyright resource collections, research materials, managing and exposing materials through websites and portals, content authoring, workflow, institutional policy and organizational resources. openEQUELLA is currently in use in a wide range of schools, universities, colleges, TAFEs, departments of education, government agencies, and corporations worldwide.
 
-With over 15 years of history, openEQUELLA is a mature solution written for the Java platform.  In its recent history, openEQUELLA was proprietary software licensed to adopters by Pearson. openEQUELLA is now available as open source software via Apereo. [Learn more about Equella and Apereo here.](https://www.apereo.org/programs/software/openequella)
+With over 15 years of history, openEQUELLA is a mature solution written for the Java platform.  In its recent history, openEQUELLA was proprietary software licensed to adopters by Pearson. openEQUELLA is now available as open source software via Apereo. [Learn more about openEQUELLA and Apereo here.](https://www.apereo.org/programs/software/openequella)
 
 ## Join the Community
 * [Apereo Equella Google Group](https://groups.google.com/a/apereo.org/forum/#!forum/equella-users) - Join the openEQUELLA user mailing list and interact with other users.

--- a/index.md
+++ b/index.md
@@ -9,11 +9,10 @@ openEQUELLA is a digital repository that provides a single platform to house you
 
 openEQUELLA has been deployed for copyright resource collections, research materials, managing and exposing materials through websites and portals, content authoring, workflow, institutional policy and organizational resources. openEQUELLA is currently in use in a wide range of schools, universities, colleges, TAFEs, departments of education, government agencies, and corporations worldwide.
 
-With over 15 years of history, openEQUELLA is a mature solution written for the Java platform.  In its recent history, openEQUELLA was proprietary software licensed to adopters by Pearson.  EQUELLA is now available as open source software via Apereo. [Learn more about Equella and Apereo here.](https://www.apereo.org/projects/equella)
+With over 15 years of history, openEQUELLA is a mature solution written for the Java platform.  In its recent history, openEQUELLA was proprietary software licensed to adopters by Pearson. openEQUELLA is now available as open source software via Apereo. [Learn more about Equella and Apereo here.](https://www.apereo.org/programs/software/openequella)
 
 ## Join the Community
 * [Apereo Equella Google Group](https://groups.google.com/a/apereo.org/forum/#!forum/equella-users) - Join the openEQUELLA user mailing list and interact with other users.
-* [openEQUELLA Community Repo](https://community.edalexcloud.com) - Public openEQUELLA instance, open for use by the openEQUELLA user community to share resources, tips and tricks, custom scripts, etc.
 * [openEQUELLA Twitter Page](https://twitter.com/EQUELLA) - Follow openEQUELLA on Twitter.
 * [Community Governance Model](community/CommunityGovernance.md) - Rules related to the Project Management Committee (PMC).
 * [Documentation Guidelines](community/DocumentationGuidelines.md) - Information about openEQUELLA GitHub repository documentation.


### PR DESCRIPTION
Updated the broken/outdated links on the OSS page at https://openequella.github.io/:
- Updated the first link [Learn more about Equella and Apereo here.] to point to the correct Apereo page. https://www.apereo.org/programs/software/openequella
- Removed the inactive community repository link as it is not currently running.